### PR TITLE
Replace font paths in text strips

### DIFF
--- a/blender/ReplacePaths.py
+++ b/blender/ReplacePaths.py
@@ -1,6 +1,5 @@
 #===========  MODIFY PARAMETERS HERE =================
 
-
 oldpath="//sound/track-1-cosh-man.wav"
 newpath="//render/sound/voice-raw-1-cosh-man.flac.wav"
 

--- a/blender/ReplacePaths.py
+++ b/blender/ReplacePaths.py
@@ -1,5 +1,6 @@
 #===========  MODIFY PARAMETERS HERE =================
 
+
 oldpath="//sound/track-1-cosh-man.wav"
 newpath="//render/sound/voice-raw-1-cosh-man.flac.wav"
 
@@ -35,6 +36,11 @@ def _replace(i, oldpath, newpath):
                 p = j.filename.replace(oldpath, newpath)
                 print("Replacing %s to %s ..." % (j.filename, p))
                 j.filename=p
+    if i.type == 'TEXT':
+        if oldpath in i.font.filepath:
+            p = i.font.filepath.replace(oldpath, newpath)
+            print("Replacing %s to %s ..." % (i.font.filepath, p))
+            i.font.filepath=p
     if i.type=='META':
         for j in i.sequences:
             _replace(j, oldpath, newpath)


### PR DESCRIPTION
Tested in Blender 3.0.1, works for strips and metastrips in the VSE.

Judging by Blender docs, i.font.filepath should be the only place that fonts are defined for a text strip, see:
* https://docs.blender.org/api/current/bpy.types.TextSequence.html?highlight=bpy%20types%20textsequence#bpy.types.TextSequence.font
* https://docs.blender.org/api/current/bpy.types.VectorFont.html#vectorfont-id

Note that Blender has not consistently recognised the change and displayed it in the preview window without saving and reopening the file, that may be just my misunderstanding of Blender though.

Please let me know if you require further testing or changes.

I found this script while looking for a way to do exactly this in Blender, so thanks!